### PR TITLE
`rc` in `nt_try_fast_exec` should be set to 1 as default.

### DIFF
--- a/win32/ntfunc.c
+++ b/win32/ntfunc.c
@@ -778,7 +778,7 @@ int nt_try_fast_exec(struct command *t) {
 	register struct varent *v;
 	register int hashval,i;
 	register int slash;
-	int rc = 0, gflag;
+	int rc = 1, gflag;
 	Char *vp;
 	Char   *blk[2];
 


### PR DESCRIPTION
First of all, let me thank you for your great software.

`rc` in `nt_try_fast_exec` should be set to 1 as default so that "Command not found." can be shown correctly.
This modification affects only Windows.

If `rc` is not updated in `do while` loop, `nt_try_fast_exec` returns 0, which means "command executed successfully".
i.e. If `bit_extern` returns 0 for all index `i`, `rc` is not updated in `do while` and `nt_try_fast_exec` returns 0.

Test case:

```
% setenv PATH C:/Windows
% rehash
% a
 => "Command not found." is not shown.
```

If my patch is pointless, let me know please.

Regards,
Murase
